### PR TITLE
build with go 1.26

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25-trixie as builder
+FROM --platform=$BUILDPLATFORM golang:1.26-trixie as builder
 
 ENV GO111MODULE=on CGO_ENABLED=0
 WORKDIR /work


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go compiler version used in the build process from 1.25 to 1.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->