### PR TITLE
Remove non-existent tests from REQUIRED_TESTS

### DIFF
--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -33,14 +33,7 @@ jobs:
       GO_VERSION: "1.23"
       REQUIRED_TESTS: '[
             "vuln_scan_triggering_with_cron_job", 
-            "ks_microservice_ns_creation",
-            "ks_microservice_on_demand", 
-            "ks_microservice_mitre_framework_on_demand", 
-            "ks_microservice_nsa_and_mitre_framework_demand", 
-            "ks_microservice_triggering_with_cron_job", 
-            "ks_microservice_update_cronjob_schedule", 
-            "ks_microservice_delete_cronjob", 
-            "ks_microservice_create_2_cronjob_mitre_and_nsa"
+            "ks_microservice_on_demand"
             ]'
       COSIGN: true
       HELM_E2E_TEST: true


### PR DESCRIPTION
## Summary
- Cleaned up `REQUIRED_TESTS` in the `pr-merged` workflow by removing 7 tests that no longer exist in `system_test_mapping.json`
- Kept `vuln_scan_triggering_with_cron_job` and `ks_microservice_on_demand` which are the only two that still exist in the mapping

## Test plan
- [ ] Verify the workflow runs correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI/CD test requirements in merge workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->