### PR TITLE
Bump Go builder to 1.26.3 to fix stdlib CVEs

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26-trixie as builder
+FROM --platform=$BUILDPLATFORM golang:1.26.3-trixie as builder
 
 ENV GO111MODULE=on CGO_ENABLED=0
 WORKDIR /work


### PR DESCRIPTION
## Summary

- Pins Go builder image from `golang:1.26-trixie` (which resolved to 1.26.2) to `golang:1.26.3-trixie`
- Fixes all 8 fixable vulnerabilities reported in the [Quay.io image manifest](https://quay.io/repository/kubescape/http-request/manifest/sha256:6337e9d4b00468c76e3e22b67d0c1252d93d8e36e43a22f230b5fd8fd43c7e02?tab=vulnerabilities&fixable=true)

## Vulnerabilities fixed (all in Go stdlib, fixed in 1.26.3)

| CVE | Description |
|-----|-------------|
| CVE-2026-33811 | Crash when handling long CNAME response in `net` |
| CVE-2026-33814 | Infinite loop in HTTP/2 transport with malformed `SETTINGS_MAX_FRAME_SIZE` |
| CVE-2026-39820 | Quadratic string concatenation in `consumeComment` in `net/mail` |
| CVE-2026-39823 | Bypass of meta content URL escaping causes XSS in `html/template` |
| CVE-2026-39825 | `ReverseProxy` forwards queries exceeding `urlmaxqueryparams` limit |
| CVE-2026-39826 | Escaper bypass leads to XSS in `html/template` |
| CVE-2026-39836 | Panic in `Dial`/`LookupPort` handling NUL byte on Windows |
| CVE-2026-42499 | Quadratic string concatenation in `consumePhrase` in `net/mail` |

## Test plan

- [ ] CI build succeeds with Go 1.26.3 builder
- [ ] Rebuilt image passes Quay.io vulnerability scan with 0 fixable stdlib CVEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base image for the build environment to a newer stable version for improved compatibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/http-request/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->